### PR TITLE
Fix to allow writing to SD cards

### DIFF
--- a/image-usb-stick
+++ b/image-usb-stick
@@ -149,8 +149,7 @@ class OsxDisk (Disk):
 			self.attrs['protocol'] == 'USB' and \
 			self.attrs['read_only_media'] == 'No' and \
 			self.attrs['ejectable'] == 'Yes' and \
-			self.attrs['whole'] == 'Yes' and \
-			self.attrs['internal'] == 'No'
+			self.attrs['whole'] == 'Yes'
 
 	def unmount (self):
 		import subprocess


### PR DESCRIPTION
We need to burn to SD cards inside macbook pro's so remove the 'internal' constraint since those live on the internal USB bus. I believe the ejectable constraint should be enough to prevent the boot drive being inadvertently overwritten.
